### PR TITLE
fix: Fix the importing of ESModule `node_modules`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
-      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
+      "version": "13.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
       "dev": true
     },
     "prettier": {
@@ -17,9 +17,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@types/node": "^13.7.1",
+    "@types/node": "^13.9.1",
     "prettier": "^1.19.1",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "typescript": "^3.7.5"
+    "typescript": ">=3.7"
   },
   "engines": {
     "node": ">= 13.7"
@@ -25,7 +25,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "prebuild": "tsc -p ./bin/",
     "build": "node --experimental-specifier-resolution=node ./out/build/build.js",
-    "pretry": "npm run build",
+    "pretry": "npm run build && cp ./test/extras/ReactPikaPKG.json ./test/node_modules/@pika/react/package.json",
     "try": "node --loader ./out/dist/index.js --experimental-specifier-resolution=node ./test/",
     "prepublishOnly": "npm run build"
   },

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -15,7 +15,7 @@ export function getTSConfig(modulePath: string): CompilerOptions {
       target: ts.ScriptTarget.ESNext,
       moduleResolution: ts.ModuleResolutionKind.NodeJs,
       allowJs: true,
-      skipLibCheck: true
+      skipLibCheck: true,
     };
   } else {
     const tsConfigFile = ts.readConfigFile(tsConfigPath, ts.sys.readFile)
@@ -23,7 +23,7 @@ export function getTSConfig(modulePath: string): CompilerOptions {
 
     tsConfigCache = ts.convertCompilerOptionsFromJson(
       tsConfigFile.compilerOptions,
-      pathDirname(tsConfigPath)
+      pathDirname(tsConfigPath),
     ).options;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,13 @@
 // src/types.ts
 
+export type ModuleFormat =
+  | 'builtin'
+  | 'commonjs'
+  | 'dynamic'
+  | 'json'
+  | 'module'
+  | 'wasm';
+
 export type Source = string | Buffer;
 
 export interface ResolveContext {

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,13 @@
+# TS-ESNode Test
+
+This is a test of all diferent TS-ESNode issues and features in an all in one application.
+
+The main entrypoint has a main import which could start an endless loop of import processing if the core import loading code is broken.
+
+The core function in the entrypoint includes some logging to ensure the process is being launched properly.
+
+It also dynamiclly loads Lab2 to ensure dynamic loading of TypeScript ESModules is working. If this is broken it could be with the findFiles function or the dynamic loading within TS-ESNode or Node.JS itself.
+
+It also imports an example SSR React rendering function [Server.tsx](./src/Server.tsx) to ensure that we can import and load TSX as well as testing the loading of ESModule's from `node_modules`, once imported we run the function and log the resulting html text to console.
+
+The NPM ESModule React module I'm using in this test/example is [@pika/react](https://github.com/pikapkg/react) to support this running in Node.JS I'm copying a package.json that includes `"type": "module"` as part of the prerun npm script.

--- a/test/extras/ReactPikaPKG.json
+++ b/test/extras/ReactPikaPKG.json
@@ -1,0 +1,44 @@
+{
+  "_from": "@pika/react",
+  "_id": "@pika/react@16.13.1",
+  "_inBundle": false,
+  "_integrity": "sha512-v33Ub2QxntNpDFRnkj3tCbT6jMb7Etu7LOMQO/YAulLRIDtDvJdMwuOVJDdPYUmDtWjfWOB5xSP7nl7k0BApbQ==",
+  "_location": "/@pika/react",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "@pika/react",
+    "name": "@pika/react",
+    "escapedName": "@pika%2freact",
+    "scope": "@pika",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": ["#USER", "/"],
+  "_resolved": "https://registry.npmjs.org/@pika/react/-/react-16.13.1.tgz",
+  "_shasum": "20e47997d2a2f1e5da39a8e28b75db2ec77d99c6",
+  "_spec": "@pika/react",
+  "_where": "/workspace/test",
+  "bugs": {
+    "url": "https://github.com/facebook/react/issues"
+  },
+  "bundleDependencies": false,
+  "type": "module",
+  "dependencies": {},
+  "deprecated": false,
+  "description": "An actively maintained ESM build of React, the JavaScript library for building user interfaces.",
+  "homepage": "https://reactjs.org/",
+  "keywords": ["react"],
+  "license": "MIT",
+  "main": "source.production.js",
+  "module": "source.production.js",
+  "name": "@pika/react",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "packages/react"
+  },
+  "version": "16.13.1"
+}

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@pika/react": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/@pika/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-v33Ub2QxntNpDFRnkj3tCbT6jMb7Etu7LOMQO/YAulLRIDtDvJdMwuOVJDdPYUmDtWjfWOB5xSP7nl7k0BApbQ=="
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -34,9 +39,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "13.1.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
-      "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
+      "version": "13.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -45,9 +50,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
-      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
+      "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -55,9 +60,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "16.9.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.4.tgz",
-      "integrity": "sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==",
+      "version": "16.9.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
+      "integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -103,9 +108,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "csstype": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
       "dev": true
     },
     "fs-extra": {
@@ -252,9 +257,9 @@
       }
     },
     "react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
+      "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -262,25 +267,25 @@
       }
     },
     "react-dom": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.0.tgz",
+      "integrity": "sha512-y09d2c4cG220DzdlFkPTnVvGTszVvNpC73v+AaLGLHbkpy3SSgvYq8x0rNwPJ/Rk/CicTNgk0hbHNw1gMEZAXg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.18.0"
+        "scheduler": "^0.19.0"
       }
     },
     "react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
     },
     "scheduler": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.0.tgz",
+      "integrity": "sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/test/package.json
+++ b/test/package.json
@@ -12,16 +12,16 @@
   "license": "ISC",
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
-    "@types/node": "^13.1.8",
-    "@types/react": "^16.9.17",
-    "@types/react-dom": "^16.9.4",
+    "@types/node": "^13.9.1",
+    "@types/react-dom": "^16.9.5",
     "typescript": "^3.8.0-dev.20200118"
   },
   "dependencies": {
+    "@pika/react": "^16.13.1",
     "fs-extra": "^8.1.0",
     "graphql": "^14.5.8",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
     "type-graphql": "^0.17.6"
   }
 }

--- a/test/src/@types/react.ts
+++ b/test/src/@types/react.ts
@@ -1,0 +1,5 @@
+declare module '@pika/react' {
+  import * as ReactTypes from '@pika/react/types/index';
+
+  export default ReactTypes;
+}

--- a/test/src/Server.tsx
+++ b/test/src/Server.tsx
@@ -1,0 +1,9 @@
+// test/src/Server.tsx
+import React from '@pika/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+export async function renderUI(): Promise<string> {
+  const [{ CoreApp }] = await Promise.all([import('./helloWorld')]);
+
+  return renderToStaticMarkup(<CoreApp />);
+}

--- a/test/src/helloWorld.tsx
+++ b/test/src/helloWorld.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from '@pika/react';
 
 export function CoreApp(): React.ReactElement {
   return (

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -17,7 +17,13 @@ async function startHelloWorld(): Promise<void> {
 
   console.log(`Result of Lab #2: `, lab2Result);
 
-  console.log('Importing helloWorld.tsx');
+  console.log('Importing Server.tsx');
+
+  const [{ renderUI }] = await Promise.all<typeof import('./Server')>([
+    import('./Server'),
+  ]);
+
+  console.log('Rendering UI', await renderUI());
 }
 
 startHelloWorld();

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -13,5 +13,5 @@
     "allowSyntheticDefaultImports": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
This should fix issue #6 and allow for the importing of `"type": "module"` ESModule from external modules in `node_modules` also adds some more testing and documentation on why/what does what to the example/test application.