### PR TITLE
Fixes #9. Work with already existingn .default export (like axios)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,16 +76,17 @@ export async function dynamicInstantiate(url: string) {
   /**
    * This is needed to allow for default exports in CommonJS modules.
    */
-  if (dynModule.default)
+  if (dynModule.default && dynModule !== dynModule.default)
     dynModule = {
       ...dynModule.default,
       ...dynModule,
     };
 
   const linkKeys = Object.keys(dynModule);
+  const exports = dynModule.default ? linkKeys : [...linkKeys, 'default'];
 
   return {
-    exports: [...linkKeys, 'default'],
+    exports,
     execute: (module: any) => {
       module.default.set(dynModule);
       // For all elements in the import set the module's key.


### PR DESCRIPTION
When the module exports a default, respect that. When the module already compensates for default by providing the same export there (such as e.g. axios) we don't want to double export that