### PR TITLE
Fix: File finder fails when file names are too similar

### DIFF
--- a/src/findFiles.ts
+++ b/src/findFiles.ts
@@ -18,9 +18,16 @@ async function findFileReadDir(
   const directoryFiles = await fs.readdir(cwd);
 
   // Filter the diretory files to only thoose with passed extenison and `.js` or `.jsx`
-  const matchedFiles = directoryFiles.filter((directoryFileName) =>
-    [...extensions, ...JS_EXTS].includes(directoryFileName.split(fileName)[1]),
-  );
+  const matchedFiles = directoryFiles.filter((directoryFileName) => {
+    for (let extension of [...extensions, ...JS_EXTS]) {
+      if(directoryFileName === fileName + extension){
+        return true;
+      }
+    }
+
+    return false;
+  });
+    
   if (matchedFiles.length > 1 || matchedFiles.length < 1) return undefined;
 
   return resolvePath(cwd, matchedFiles[0]);


### PR DESCRIPTION
When the file finder comes across two or more files in the same directory with names that are too similar, they are disregarded and the error "No files found by finder" is thrown.

**Example:**
I have two files in one directory, `StatusEndpoint.ts` and `BadgeStatusEndpoint.ts`. When the finder comes across the first, it also matches the second file, which creates the error. I have updated the function to only match exact file names.