### PR TITLE
fix(dynamicInstantiate): works with pnpm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,9 @@ export async function resolve(
 export async function dynamicInstantiate(url: string) {
   const moduleUrl = new URL(url);
 
-  const [nodeModulesBase, specifier] = moduleUrl.pathname.split(
-    'node_modules/',
-  );
+  const pathParts = moduleUrl.pathname.split('node_modules/');
+  const specifier = pathParts.pop()!;
+  const nodeModulesBase = pathParts.join('node_modules/');
 
   const nodeModuleUrl = new URL('node_modules', pathToFileURL(nodeModulesBase));
 


### PR DESCRIPTION
This commit fixes the path splitting algorithm in `dynamicInstantiate`, so that it can work with a `node_modules` tree installed by [pnpm](https://pnpm.js.org/).

Previously, the code splits the URL of to-be-loaded module with `node_modules/`, and take the first part as base directory and the second part part as package name.
However, a `node_modules` tree installed by pnpm contains multiple `node_modules/` components to reach a package, such as `node_modules/.pnpm/registry.npmjs.org/stdout-stream/1.4.1/node_modules/stdout-stream`, while `node_modules/stdout-stream` is a symbolic link to that directory.
The old splitting code would think `.pnpm/registry.npmjs.org/stdout-stream/1.4.1` is the package name, which is incorrect.

---

To reproduce the bug with pnpm, save the following files, then install dependencies with `pnpm install`.
**package.json**
```json
{
  "private": true,
  "type": "module",
  "scripts": {
    "build": "tsc --noEmit",
    "dev": "node --loader @k-foss/ts-esnode --experimental-specifier-resolution=node main.ts"
  },
  "dependencies": {
    "stdout-stream": "^1.4.1"
  },
  "devDependencies": {
    "@k-foss/ts-esnode": "*",
    "@types/stdout-stream": "^1.4.0",
    "typescript": "^3.8.3"
  }
}
```
**tsconfig.json**
```jsonc
{
  "compilerOptions": {
    "allowSyntheticDefaultImports": true,
    "module": "ESNext",
    "target": "ESNext",
    "moduleResolution": "Node"
  }
}
```
**main.ts**
```ts
import stdout from "stdout-stream";
stdout.write("OK\n");
```
