### PR TITLE
fix(dot import): Fix `import XYZ from '.'`

### DIFF
--- a/Testing/Tests/DotImport/package-lock.json
+++ b/Testing/Tests/DotImport/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "dotimport",
+  "version": "0.0.0",
+  "lockfileVersion": 1
+}

--- a/Testing/Tests/DotImport/package.json
+++ b/Testing/Tests/DotImport/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dotimport",
+  "version": "0.0.0",
+  "description": "",
+  "main": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/Testing/Tests/DotImport/src/Hello/helloWorld.ts
+++ b/Testing/Tests/DotImport/src/Hello/helloWorld.ts
@@ -1,0 +1,5 @@
+// DotImport/src/Hello/helloWorld.ts
+import { helloString } from '.';
+import { deepEqual } from 'assert';
+
+deepEqual(helloString, 'helloWorld', 'helloString does not equal helloWorld');

--- a/Testing/Tests/DotImport/src/Hello/index.ts
+++ b/Testing/Tests/DotImport/src/Hello/index.ts
@@ -1,0 +1,2 @@
+// src/Hello/index.ts
+export const helloString = 'helloWorld';

--- a/Testing/Tests/DotImport/src/index.ts
+++ b/Testing/Tests/DotImport/src/index.ts
@@ -1,0 +1,21 @@
+// Template/src/index.ts
+
+export async function startApp(): Promise<void> {
+  console.log('Starting DotImport test');
+
+  console.log('Loading randomLoader');
+
+  const { loadRandom } = await import('./randomLoader');
+
+  console.log('Running loadRandom()');
+
+  const result = await loadRandom();
+
+  console.log('loadRandom() result: ', result);
+
+  console.debug('Done');
+}
+
+startApp();
+
+export {};

--- a/Testing/Tests/DotImport/src/randomLoader.ts
+++ b/Testing/Tests/DotImport/src/randomLoader.ts
@@ -1,0 +1,10 @@
+// DotImport/src/randomLoader.ts
+export async function loadRandom(): Promise<boolean> {
+  console.log('Importing Hello/helloWorld.ts');
+
+  await import('./Hello/helloWorld');
+
+  console.log('Imported Hello/helloWorld.ts');
+
+  return true;
+}

--- a/Testing/Tests/DotImport/tsconfig.json
+++ b/Testing/Tests/DotImport/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { getTSConfig } from './Utils';
 const rootModulePath = `${process.cwd()}/`;
 const baseURL = pathToFileURL(rootModulePath).href;
 
-const relativePathRegex = /^\.{1,2}[/]/;
+const relativePathRegex = /^\.{1,2}[/]?/;
 const hasExtensionRegex = /\.\w+$/;
 
 // TODO: Allow customization of extensions


### PR DESCRIPTION
closes issue #34 by refactoring the relative path test regex to have the ending / be optional