### PR TITLE
ci(TSC): Add `tsc` type-checking to `Code Quality.yml` workflow

### DIFF
--- a/.github/workflows/Code Quality.yml
+++ b/.github/workflows/Code Quality.yml
@@ -1,6 +1,12 @@
 name: Code Quality
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   Prettier:
@@ -12,12 +18,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1.4.1
         with:
           node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run Prettier
         run: npm run prettier
 
@@ -30,11 +39,35 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1.4.1
         with:
           node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run ESLint
         run: npm run lint
+
+  TSC:
+    name: TSC Typecheck
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        node: ['14.x']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1.4.1
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TSC Typechecking
+        run: npm run typecheck

--- a/.github/workflows/Push.yml
+++ b/.github/workflows/Push.yml
@@ -1,6 +1,12 @@
 name: Testing
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   Test:
@@ -12,11 +18,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1.4.1
         with:
           node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run Tests
         run: npm run test

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,4 +1,4 @@
-name: NPM Publish
+name: Release
 
 on:
   push:
@@ -16,12 +16,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1.4.1
         with:
           node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run Tests
         run: npm run test
 
@@ -31,18 +34,24 @@ jobs:
     needs: [Test]
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1.4.1
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: npm ci
-      - name: Release
+
+      ## Run [semantic-release](https://github.com/semantic-release/semantic-release) auto release/publish system
+      - name: Run semantic-release
+        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+          ## Dedicated bot user for all @K-FOSS Repos
           GIT_AUTHOR_NAME: 'KJDev-Bots'
           GIT_COMMITTER_NAME: 'KJDev-Bots'
           GIT_AUTHOR_EMAIL: 'bots@kristianjones.dev'
           GIT_COMMITTER_EMAIL: 'bots@kristianjones.dev'
-        run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "try": "node --loader ./out/dist/index.js --experimental-specifier-resolution=node ./test/",
     "prepublishOnly": "npm run build",
     "prettier": "prettier --config .prettierrc --check \"src/**/*ts\" \"bin/**/*.ts\"",
-    "lint": "eslint -c .eslintrc.json . --ext .js,.ts"
+    "lint": "eslint -c .eslintrc.json . --ext .js,.ts",
+    "typecheck": "tsc --noEmit"
   },
   "author": {
     "email": "me@kristianjones.dev",

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ export async function getFormat(
 
 export async function transformSource(
   source: Source,
-  context: string,
+  context: TransformContext,
   defaultTransformSource: Function,
 ): Promise<TransformResponse> {
   const resolvedUrl = new URL(context.url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ export async function getFormat(
 
 export async function transformSource(
   source: Source,
-  context: TransformContext,
+  context: string,
   defaultTransformSource: Function,
 ): Promise<TransformResponse> {
   const resolvedUrl = new URL(context.url);


### PR DESCRIPTION
This PR adds `tsc --noEmit` as a typecheck command for `npm run typecheck`.]

The PR also adds a new TSC job to the `Code Quality.yml` workflow to allow for GitHub problem matching in PR code review.