### PR TITLE
chore(Dependabot): Hopefully Fix Dependabot weirdness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
     schedule:
       interval: daily
     versioning-strategy: increase
+    allow:
+      - dependency-type: direct
     assignees:
       - KristianFJones
     reviewers:


### PR DESCRIPTION
Attempting to fix Dependabot not "updating" our dependencies properly. It has failed to create a PR for the `eslint` dependency among others.